### PR TITLE
Attach meta object to lighthouse results

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Submit to process website with Google Lighthouse.
 | commands | `array<Commmand>` | optional | [DevTool Commands](https://chromedevtools.github.io/devtools-protocol/) to be executed prior to running Lighthouse |
 | commands[idx].command | `string` | **required** | [DevTool Command](https://chromedevtools.github.io/devtools-protocol/) to execute |
 | commands[idx].options | `object` | **required** | [DevTool Command Options](https://chromedevtools.github.io/devtools-protocol/) to supply command |
+| websiteMeta | `object` | optional | Object containing metadata that will be attached to final lighthouse results |
 
 
 ### Command

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Submit to process website with Google Lighthouse.
 | commands | `array<Commmand>` | optional | [DevTool Commands](https://chromedevtools.github.io/devtools-protocol/) to be executed prior to running Lighthouse |
 | commands[idx].command | `string` | **required** | [DevTool Command](https://chromedevtools.github.io/devtools-protocol/) to execute |
 | commands[idx].options | `object` | **required** | [DevTool Command Options](https://chromedevtools.github.io/devtools-protocol/) to supply command |
-| websiteMeta | `object` | optional | Object containing metadata that will be attached to final lighthouse results |
+| meta | `object` | optional | Object containing metadata that will be attached to final lighthouse results |
 
 
 ### Command

--- a/src/express/api/post-website.js
+++ b/src/express/api/post-website.js
@@ -7,7 +7,7 @@ const crypto = require('crypto');
 const papa = require('papaparse');
 
 module.exports = async (req, res) => {
-  const { report = true, queue: canQueue = true, batch, wait, url, headers, secureHeaders, commands, cookies, auditMode, samples, attempts, hostOverride, delay: delayStr, group = 'unknown' } = req.body;
+  const { report = true, queue: canQueue = true, batch, wait, url, headers, secureHeaders, commands, cookies, auditMode, samples, attempts, hostOverride, delay: delayStr, group = 'unknown', websiteMeta } = req.body;
 
   let documentRequests;
 
@@ -141,7 +141,8 @@ module.exports = async (req, res) => {
         delay,
         delayTime,
         state: 'requested',
-        createDate: Date.now()
+        createDate: Date.now(),
+        websiteMeta
       };
 
     });

--- a/src/express/api/post-website.js
+++ b/src/express/api/post-website.js
@@ -7,7 +7,7 @@ const crypto = require('crypto');
 const papa = require('papaparse');
 
 module.exports = async (req, res) => {
-  const { report = true, queue: canQueue = true, batch, wait, url, headers, secureHeaders, commands, cookies, auditMode, samples, attempts, hostOverride, delay: delayStr, group = 'unknown', websiteMeta } = req.body;
+  const { report = true, queue: canQueue = true, batch, wait, url, headers, secureHeaders, commands, cookies, auditMode, samples, attempts, hostOverride, delay: delayStr, group = 'unknown', meta } = req.body;
 
   let documentRequests;
 
@@ -142,7 +142,7 @@ module.exports = async (req, res) => {
         delayTime,
         state: 'requested',
         createDate: Date.now(),
-        websiteMeta
+        meta
       };
 
     });
@@ -153,7 +153,7 @@ module.exports = async (req, res) => {
       doc.id = id;
 
       if (canQueue) {      // do not queue until the document has been indexed
-        await queue.enqueue(doc);  
+        await queue.enqueue(doc);
       } else {
         // process inline
         doc = await processMessage({ config, store }, null, doc);

--- a/src/lighthouse/submit.js
+++ b/src/lighthouse/submit.js
@@ -34,7 +34,7 @@ const ALLOWED_KEYS = {
 
 module.exports = async (url, { lighthouse: baseConfig, queue, launcher }, options) => {
   const config = Object.assign({}, baseConfig.config);
-  const { hostOverride, group, secureHeaders, cipherVector, commands, cookies, websiteMeta } = options;
+  const { hostOverride, group, secureHeaders, cipherVector, commands, cookies, meta } = options;
 
   // only pull over whitelisted options
   Object.keys(options).forEach(optionKey => {
@@ -90,7 +90,7 @@ module.exports = async (url, { lighthouse: baseConfig, queue, launcher }, option
 
   const results = [];
   for (let sample = 0; sample < samples; sample++) {
-    results[sample] = await getLighthouseResult(url, config, { report, launcher, auditMode, throttlingPreset, hostOverride, commands: decryptedCommands, cookies: decryptedCookies, websiteMeta });
+    results[sample] = await getLighthouseResult(url, config, { report, launcher, auditMode, throttlingPreset, hostOverride, commands: decryptedCommands, cookies: decryptedCookies, meta });
   }
 
   // take the top result
@@ -192,7 +192,7 @@ function getCommandsFromCookies(cookies, { url }) {
   return commands;
 }
 
-async function getLighthouseResult(url, config, { launcher, auditMode, throttlingPreset, hostOverride, report, commands = [], cookies = [], websiteMeta}) {
+async function getLighthouseResult(url, config, { launcher, auditMode, throttlingPreset, hostOverride, report, commands = [], cookies = [], meta }) {
   const chromeOptions = { chromeFlags: config.chromeFlags };
   if (hostOverride) {
     const { host } = URL.parse(url);
@@ -277,8 +277,8 @@ async function getLighthouseResult(url, config, { launcher, auditMode, throttlin
         delete lhr.timing.entries;
       }
 
-      if (websiteMeta) {
-        lhr.websiteMeta = websiteMeta;
+      if (meta) {
+        lhr.meta = meta;
       }
 
       // use results.lhr for the JS-consumeable output

--- a/src/lighthouse/submit.js
+++ b/src/lighthouse/submit.js
@@ -29,13 +29,12 @@ const ALLOWED_KEYS = {
   categories: true,
   categoryGroups: true,
   timing: true,
-  i18n: false,
-  websiteMeta: true
+  i18n: false
 };
 
 module.exports = async (url, { lighthouse: baseConfig, queue, launcher }, options) => {
   const config = Object.assign({}, baseConfig.config);
-  const { hostOverride, group, secureHeaders, cipherVector, commands, cookies } = options;
+  const { hostOverride, group, secureHeaders, cipherVector, commands, cookies, websiteMeta } = options;
 
   // only pull over whitelisted options
   Object.keys(options).forEach(optionKey => {
@@ -91,7 +90,7 @@ module.exports = async (url, { lighthouse: baseConfig, queue, launcher }, option
 
   const results = [];
   for (let sample = 0; sample < samples; sample++) {
-    results[sample] = await getLighthouseResult(url, config, { report, launcher, auditMode, throttlingPreset, hostOverride, commands: decryptedCommands, cookies: decryptedCookies });
+    results[sample] = await getLighthouseResult(url, config, { report, launcher, auditMode, throttlingPreset, hostOverride, commands: decryptedCommands, cookies: decryptedCookies, websiteMeta });
   }
 
   // take the top result
@@ -109,7 +108,6 @@ module.exports = async (url, { lighthouse: baseConfig, queue, launcher }, option
   }
 
   // todo: permit configurable categories.. for example score = sum of each category
-
   return result;
 };
 
@@ -194,7 +192,7 @@ function getCommandsFromCookies(cookies, { url }) {
   return commands;
 }
 
-async function getLighthouseResult(url, config, { launcher, auditMode, throttlingPreset, hostOverride, report, commands = [], cookies = [] }) {
+async function getLighthouseResult(url, config, { launcher, auditMode, throttlingPreset, hostOverride, report, commands = [], cookies = [], websiteMeta}) {
   const chromeOptions = { chromeFlags: config.chromeFlags };
   if (hostOverride) {
     const { host } = URL.parse(url);
@@ -279,8 +277,8 @@ async function getLighthouseResult(url, config, { launcher, auditMode, throttlin
         delete lhr.timing.entries;
       }
 
-      if (config.settings.websiteMeta) {
-        lhr.websiteMeta = config.settings.websiteMeta;
+      if (websiteMeta) {
+        lhr.websiteMeta = websiteMeta;
       }
 
       // use results.lhr for the JS-consumeable output

--- a/src/lighthouse/submit.js
+++ b/src/lighthouse/submit.js
@@ -29,7 +29,8 @@ const ALLOWED_KEYS = {
   categories: true,
   categoryGroups: true,
   timing: true,
-  i18n: false
+  i18n: false,
+  websiteMeta: true
 };
 
 module.exports = async (url, { lighthouse: baseConfig, queue, launcher }, options) => {
@@ -276,6 +277,10 @@ async function getLighthouseResult(url, config, { launcher, auditMode, throttlin
       if (lhr.timing) {
         // not yet supported
         delete lhr.timing.entries;
+      }
+
+      if (config.settings.websiteMeta) {
+        lhr.websiteMeta = config.settings.websiteMeta;
       }
 
       // use results.lhr for the JS-consumeable output

--- a/test/unit/express/api/post-website.test.js
+++ b/test/unit/express/api/post-website.test.js
@@ -10,10 +10,11 @@ const libSrc = path.resolve('./src/express/api/post-website.js');
 
 describe('/express/api/post-website', async () => {
 
-  let lib, mocks;
+  let lib, mocks, meta;
 
   beforeEach(() => {
     mocks = getMocks();
+    meta = { identifier: 'test' };
     mocks.request.body = {
       'url': 'https://www.google.com/',
       'throttling': 'mobile3G',
@@ -21,7 +22,8 @@ describe('/express/api/post-website', async () => {
       'headers': {},
       'secureHeaders': { secretKey: 'secretValue' },
       'cookies': [{ cookie1: 'c1', cookie2: { domain: 'domain', url: 'url', value: 'c2' } }],
-      'commands': [{ command: 'command' }]
+      'commands': [{ command: 'command' }],
+      'meta': meta
     };
     lib = proxyquire(libSrc, mocks);
   });
@@ -45,4 +47,8 @@ describe('/express/api/post-website', async () => {
     expect(mocks.response.sendStatus).to.be.calledWith(500);
   });
 
+  it('passes through meta', async () => {
+    await lib(mocks.request, mocks.response);
+    expect(mocks.response.send.args[0][0].meta).to.equal(meta);
+  });
 });


### PR DESCRIPTION
update `lighthouse/submit` to attach a `meta` key that is intended to contain identifiers to help aid analytics via filters

Example request in local to pass along `websiteMeta`, with `websiteMeta` existing on the POST req response

note: renamed `websiteMeta` -> `meta` but the screenshot has not been updated

![Screen Shot 2021-01-21 at 4 22 09 PM](https://user-images.githubusercontent.com/16908603/105429009-71df8d00-5c05-11eb-8718-7a2e316841ba.png)
