### PR TITLE
fix(submit): Update ChromeLauncher cleanup

### DIFF
--- a/src/lighthouse/submit.js
+++ b/src/lighthouse/submit.js
@@ -285,10 +285,12 @@ async function getLighthouseResult(url, config, { launcher, auditMode, throttlin
       // https://github.com/GoogleChrome/lighthouse/blob/master/typings/lhr.d.ts
       // use results.report for the HTML/JSON/CSV output as a string
       // use results.artifacts for the trace/screenshots/other specific case you need (rarer)
-      chrome.kill().then(() => resolve(lhr)).catch(ex => reject(ex));
+      await chrome.kill();
+      resolve(lhr);
     } catch (ex) {
       clearTimeout(timer);
-      chrome.kill().then(() => reject(ex)).catch(() => reject(ex));
+      await chrome.kill();
+      reject(ex);
     }
   });
 }


### PR DESCRIPTION
We're seeing `TypeError: Cannot read properties of undefined (reading 'then')` on our lh4u pods.

Digging deeper, it seems ChromeLauncher `kill()` doesn't return a Promise [as documented](https://github.com/GoogleChrome/chrome-launcher?tab=readme-ov-file#launched-chrome-interface). It doesn't appear related to the recent lighthouse bump from 9.5.0 -> 9.6.8; the old version had the same issue, but not sure why it didn't surface.

This update follows their [examples](https://github.com/GoogleChrome/lighthouse/blob/main/cli/test/smokehouse/lighthouse-runners/bundle.js#L100) on chrome cleanup